### PR TITLE
Implement Identity Contract Client Example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ target
 #.idea/
 
 .contract_id
+.identity_contract_id
 test_snapshots
 Cargo.lock
 scripts/measure_ultrahonk_costs/node_modules/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -311,9 +311,9 @@ checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
 name = "autocfg"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "base16ct"
@@ -343,10 +343,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "bumpalo"
-version = "3.20.2"
+name = "bs58"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+checksum = "bf88ba1141d185c399bee5288d850d63b8369520c1eafc32a0430b5b6c287bf4"
+dependencies = [
+ "tinyvec",
+]
+
+[[package]]
+name = "bumpalo"
+version = "3.20.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
 name = "byteorder"
@@ -368,9 +377,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.60"
+version = "1.2.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43c5703da9466b66a946814e1adf53ea2c90f10063b86290cc9eb67ce3478a20"
+checksum = "556e016178bb5662a08681bbe0f00f8e17631781a4dfc8c45e466e4b185ec27f"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -573,9 +582,9 @@ dependencies = [
 
 [[package]]
 name = "data-encoding"
-version = "2.10.0"
+version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
+checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
 
 [[package]]
 name = "der"
@@ -710,9 +719,9 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.15.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
 
 [[package]]
 name = "elliptic-curve"
@@ -799,6 +808,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
+name = "futures-core"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-task"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+
+[[package]]
+name = "futures-util"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "pin-project-lite",
+ "slab",
+]
+
+[[package]]
 name = "generic-array"
 version = "0.14.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -868,9 +901,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.17.0"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
 name = "heapless"
@@ -970,7 +1003,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.17.0",
+ "hashbrown 0.17.1",
  "serde",
  "serde_core",
 ]
@@ -1007,10 +1040,12 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "js-sys"
-version = "0.3.95"
+version = "0.3.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2964e92d1d9dc3364cae4d718d93f227e3abb088e747d92e0395bfdedf1c12ca"
+checksum = "142bc4740e452c1e57ade0cbc129f139c9093e354346f0872ef985f4f5cf5f11"
 dependencies = [
+ "cfg-if",
+ "futures-util",
  "once_cell",
  "wasm-bindgen",
 ]
@@ -1038,9 +1073,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.185"
+version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52ff2c0fe9bc6cb6b14a0592c2ff4fa9ceb83eea9db979b0487cd054946a2b8f"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "libm"
@@ -1050,9 +1085,9 @@ checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "log"
-version = "0.4.29"
+version = "0.4.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+checksum = "953f07c43838f8e6f9758cab68bf5bed85465e7587ebe0b823f1bcd81978ad3a"
 
 [[package]]
 name = "macro-string"
@@ -1067,9 +1102,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.8.0"
+version = "2.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+checksum = "6b947ae49db0d222b1dbc6b113ce7248a3fc3a6ca21b696717bfc000ba4484d8"
 
 [[package]]
 name = "num-bigint"
@@ -1083,9 +1118,9 @@ dependencies = [
 
 [[package]]
 name = "num-conv"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
+checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
 
 [[package]]
 name = "num-derive"
@@ -1139,6 +1174,12 @@ name = "paste"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pkcs8"
@@ -1372,9 +1413,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.149"
+version = "1.0.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
 dependencies = [
  "itoa",
  "memchr",
@@ -1385,11 +1426,12 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.18.0"
+version = "3.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd5414fad8e6907dbdd5bc441a50ae8d6e26151a03b1de04d89a5576de61d01f"
+checksum = "e72c1c2cb7b223fafb600a619537a871c2818583d619401b785e7c0b746ccde2"
 dependencies = [
  "base64",
+ "bs58",
  "chrono",
  "hex",
  "indexmap 1.9.3",
@@ -1405,9 +1447,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "3.18.0"
+version = "3.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3db8978e608f1fe7357e211969fd9abdcae80bac1ba7a3369bb7eb6b404eb65"
+checksum = "b90c488738ecb4fb0262f41f43bc40efc5868d9fb744319ddf5f5317f417bfac"
 dependencies = [
  "darling 0.23.0",
  "proc-macro2",
@@ -1438,9 +1480,9 @@ dependencies = [
 
 [[package]]
 name = "shlex"
-version = "1.3.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "signature"
@@ -1451,6 +1493,12 @@ dependencies = [
  "digest",
  "rand_core",
 ]
+
+[[package]]
+name = "slab"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "smallvec"
@@ -1912,6 +1960,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinyvec"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
 name = "tornado_classic_contracts"
 version = "0.1.0"
 dependencies = [
@@ -1925,9 +1988,9 @@ dependencies = [
 
 [[package]]
 name = "typenum"
-version = "1.20.0"
+version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
 name = "ultrahonk-test-utils"
@@ -1977,9 +2040,9 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.118"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bf938a0bacb0469e83c1e148908bd7d5a6010354cf4fb73279b7447422e3a89"
+checksum = "3ed04576f974d2b2fba0f38c51dbc5518011e38c36bf1143164be765528fd409"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -1990,9 +2053,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.118"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eeff24f84126c0ec2db7a449f0c2ec963c6a49efe0698c4242929da037ca28ed"
+checksum = "916151b09da36bd82f6615cbf3a419e2f0ba23a03c6160e8e92eb6bd4aa1dec6"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -2000,9 +2063,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.118"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d08065faf983b2b80a79fd87d8254c409281cf7de75fc4b773019824196c904"
+checksum = "299047362ccbfce148b67ab7e73349f77748e00c8296f9542adfad2ad82c5c5e"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -2013,9 +2076,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.118"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fd04d9e306f1907bd13c6361b5c6bfc7b3b3c095ed3f8a9246390f8dbdee129"
+checksum = "9a929b2c61f11ba3e9bc35b50c1f25cb38e0e892c0c231ae2b8cf78d5dad4437"
 dependencies = [
  "unicode-ident",
 ]
@@ -2134,18 +2197,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.48"
+version = "0.8.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
+checksum = "3b065d4f0e55f82fae73202e189638116a87c55ab6b8e6c2721e13dd9d854ad1"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.48"
+version = "0.8.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
+checksum = "0b631b19d36a892ab55420c92dbc83ccd79274f25be714855d3074aa71cab639"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/contracts/identity/README.md
+++ b/contracts/identity/README.md
@@ -1,0 +1,122 @@
+# Identity Contract
+
+A minimal Soroban smart contract that verifies on-chain identity proofs using the UltraHonk verifier.
+
+## What it proves
+
+The accompanying Noir circuit (`circuits/identity/`) proves knowledge of a **Poseidon2 hash preimage**:
+
+```noir
+fn main(preimage: Field, hash: pub Field) {
+    let computed_hash = Poseidon2::hash([preimage], 1);
+    assert(computed_hash == hash);
+}
+```
+
+- **Private input**: `preimage` — the secret value (e.g., a password, seed, or identity secret)
+- **Public input**: `hash` — the Poseidon2 hash of the preimage, stored on-chain
+
+## Contract API
+
+### Constructor
+
+```rust
+fn __constructor(env: Env, vk_bytes: Bytes)
+```
+
+Stores the UltraHonk verification key in contract instance storage. This VK is tied to the specific Noir circuit and must be generated with the same `bb` version used to produce proofs.
+
+### Methods
+
+```rust
+fn prove_identity(env: Env, public_inputs: Bytes, proof_bytes: Bytes) -> Result<(), Error>
+```
+
+Verifies a proof that the caller knows the preimage for the given public hash.
+
+**Errors:**
+- `VkNotSet` — contract was not initialized with a VK
+- `VkParseError` — VK deserialization failed (wrong format or version)
+- `ProofParseError` — proof length does not match `PROOF_BYTES` (14,592)
+- `VerificationFailed` — proof is invalid for the given public inputs
+
+## Architecture
+
+```
+┌─────────────────┐     ┌──────────────────────┐     ┌─────────────────┐
+│   Prover (off-  │     │   Identity Contract   │     │  Verifier Crate │
+│   chain)        │     │   (Soroban guest)     │     │  (embedded)     │
+│                 │     │                      │     │                 │
+│  nargo execute  │────▶│  prove_identity()    │────▶│  UltraHonk      │
+│  bb prove       │     │  - loads VK          │     │  Verifier       │
+│                 │     │  - deserializes      │     │                 │
+│                 │     │    proof + inputs    │     │  - host BN254    │
+│                 │     │  - delegates to      │     │    primitives    │
+│                 │     │    verifier          │     │                 │
+└─────────────────┘     └──────────────────────┘     └─────────────────┘
+```
+
+The contract itself is ~24KB WASM. Verification costs ~81M CPU instructions on Soroban Protocol 26.
+
+## End-to-End Flow
+
+### 1. Build the circuit
+
+```bash
+just build-circuits identity
+```
+
+This generates in `circuits/identity/target/`:
+- `proof` — the UltraHonk proof (14,592 bytes)
+- `vk` — the verification key
+- `public_inputs` — the public hash (32 bytes)
+
+### 2. Build & deploy the contract
+
+```bash
+# Localnet
+just start          # start local stellar node
+just fund           # fund alice account
+./scripts/run_identity_e2e.sh
+
+# Testnet
+./scripts/run_identity_e2e.sh testnet
+```
+
+The script deploys the contract with the VK as a constructor argument.
+
+### 3. Verify on-chain
+
+The `run_identity_e2e.sh` script automatically calls `prove_identity` after deployment. To invoke manually:
+
+```bash
+cd scripts/invoke_identity
+npm install
+npx ts-node invoke_identity.ts prove \
+  --contract-id <CONTRACT_ID> \
+  --dataset ../../circuits/identity/target \
+  --network local \
+  --source-account alice \
+  --send yes
+```
+
+## Testing
+
+Run the unit test (in-memory Soroban environment, no network needed):
+
+```bash
+cargo test -p identity
+```
+
+The test loads circuit artifacts from `circuits/identity/target/` using `ultrahonk-test-utils::Fixture`.
+
+## Customizing the circuit
+
+Edit `circuits/identity/src/main.nr` and `circuits/identity/Prover.toml`:
+
+```toml
+preimage = "12345"
+hash = "0x..."
+```
+
+Then rebuild and redeploy. The VK changes whenever the circuit changes, so the contract must be re-deployed (or a multi-VK pattern implemented).

--- a/justfile
+++ b/justfile
@@ -4,6 +4,10 @@
 set dotenv-load := true
 set shell := ["bash", "-cu"]
 
+# =============================================================================
+# General
+# =============================================================================
+
 # Show available commands (default)
 default:
     @just --list
@@ -11,6 +15,16 @@ default:
 # Check dependencies, install Node packages, add Rust target
 setup:
     ./scripts/setup.sh
+
+# Clean up: stop container and remove generated contract IDs
+clean:
+    ./scripts/stop_stellar.sh 2>/dev/null || true
+    rm -f .contract_id .identity_contract_id
+    @echo "Cleaned up localnet state"
+
+# =============================================================================
+# Network
+# =============================================================================
 
 # Start the Stellar localnet container (pass extra args to `stellar container start`)
 start *args="":
@@ -24,16 +38,28 @@ stop:
 fund:
     ./scripts/fund_account.sh
 
+# =============================================================================
+# Circuits
+# =============================================================================
+
 # Build circuits (proof, vk, public_inputs). Builds all circuits by default;
-# pass one or more names to build only those (e.g. `just build-circuits simple_circuit`).
+# pass one or more names to build only those (e.g. `just build-circuits simple_circuit identity`).
 build-circuits *names="":
     bash ./circuits/scripts/build_all.sh {{names}}
+
+# =============================================================================
+# Contracts — General
+# =============================================================================
 
 # Build the Soroban contract WASM (pass extra args to `stellar contract build`)
 build-contract *args="":
     stellar contract build {{args}}
 
-# Deploy contract (builds circuits, builds contract, deploys with retry logic)
+# =============================================================================
+# Tornado / Default Verifier Contract
+# =============================================================================
+
+# Deploy the default (Tornado) verifier contract (builds circuits, builds contract, deploys with retry logic)
 deploy:
     ./scripts/deploy.sh
 
@@ -50,8 +76,55 @@ e2e:
 testnet:
     ./scripts/run_testnet_e2e.sh
 
-# Clean up: stop container and remove generated contract ID
-clean:
-    ./scripts/stop_stellar.sh 2>/dev/null || true
-    rm -f .contract_id
-    @echo "Cleaned up localnet state"
+# =============================================================================
+# Identity Contract
+# =============================================================================
+
+# Build only the Identity contract WASM
+build-identity-contract:
+    cargo build --release --target wasm32v1-none --package identity
+
+# Deploy the Identity contract with the identity circuit's VK
+deploy-identity:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    source ./scripts/config.sh
+    CIRCUIT_DIR="$ROOT_DIR/circuits/identity"
+    CONTRACT_WASM="$ROOT_DIR/target/wasm32v1-none/release/identity.wasm"
+    just build-circuits identity
+    stellar contract build
+    ./scripts/fund_account.sh
+    CONTRACT_ID=$(stellar contract deploy \
+      --wasm "$CONTRACT_WASM" \
+      --source "$STELLAR_SOURCE_ACCOUNT" \
+      --network "$STELLAR_NETWORK_NAME" \
+      -- \
+      --vk_bytes-file-path "$CIRCUIT_DIR/target/vk")
+    echo "$CONTRACT_ID" > "$ROOT_DIR/.identity_contract_id"
+    echo "Identity contract deployed: $CONTRACT_ID"
+
+# Verify an identity proof on-chain.
+# If no contract_id is provided, reads from .identity_contract_id file.
+verify-identity contract_id="":
+    #!/usr/bin/env bash
+    set -euo pipefail
+    source ./scripts/config.sh
+    CIRCUIT_DIR="$ROOT_DIR/circuits/identity"
+    if [ -z "{{contract_id}}" ]; then
+      CONTRACT_ID=$(cat "$ROOT_DIR/.identity_contract_id")
+    else
+      CONTRACT_ID="{{contract_id}}"
+    fi
+    stellar contract invoke \
+      --id "$CONTRACT_ID" \
+      --source "$STELLAR_SOURCE_ACCOUNT" \
+      --network "$STELLAR_NETWORK_NAME" \
+      --send yes \
+      -- \
+      prove_identity \
+      --public_inputs-file-path "$CIRCUIT_DIR/target/public_inputs" \
+      --proof_bytes-file-path "$CIRCUIT_DIR/target/proof"
+
+# Run the full Identity E2E pipeline (build circuit → build contract → deploy → prove)
+identity-e2e network="local":
+    ./scripts/run_identity_e2e.sh {{network}}

--- a/scripts/invoke_identity/invoke_identity.ts
+++ b/scripts/invoke_identity/invoke_identity.ts
@@ -1,0 +1,171 @@
+#!/usr/bin/env ts-node
+/**
+ * Identity Contract Client
+ *
+ * Invokes the Identity contract's `prove_identity` method.
+ * The identity circuit proves knowledge of a Poseidon2 hash preimage.
+ *
+ * Example (localnet):
+ *   npx ts-node invoke_identity.ts prove \
+ *       --contract-id CDB... \
+ *       --dataset ../../circuits/identity/target \
+ *       --network local --source-account alice --send yes
+ *
+ * Example (testnet):
+ *   npx ts-node invoke_identity.ts prove \
+ *       --contract-id CDB... \
+ *       --dataset ../../circuits/identity/target \
+ *       --network testnet --source-account alice --send yes
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+import { spawn } from 'child_process';
+import { ArgumentParser } from 'argparse';
+
+const REPO_ROOT = path.resolve(__dirname, '..', '..');
+const DEFAULT_DATASET_DIR = path.resolve(REPO_ROOT, 'circuits', 'identity', 'target');
+
+// === Data loading ============================================================
+
+function loadArtifacts(dataset: string): { publicInputsBytes: Buffer; proofBytes: Buffer } {
+  const publicInputsPath = path.join(dataset, 'public_inputs');
+  const proofPath = path.join(dataset, 'proof');
+
+  if (!fs.existsSync(publicInputsPath)) {
+    throw new Error(`public inputs not found: ${publicInputsPath}`);
+  }
+  if (!fs.existsSync(proofPath)) {
+    throw new Error(`proof not found: ${proofPath}`);
+  }
+
+  return {
+    publicInputsBytes: fs.readFileSync(publicInputsPath),
+    proofBytes: fs.readFileSync(proofPath),
+  };
+}
+
+// === CLI helpers =============================================================
+
+function runCommand(cmd: string[], dryRun: boolean): Promise<{ returncode: number; stdout: string; stderr: string }> {
+  const display = cmd.map((p) => (p.includes(' ') ? `"${p}"` : p)).join(' ');
+
+  if (dryRun) {
+    console.log(`[dry-run] ${display}`);
+    return Promise.resolve({ returncode: 0, stdout: '', stderr: '' });
+  }
+
+  return new Promise((resolve) => {
+    const child = spawn(cmd[0], cmd.slice(1), { stdio: ['inherit', 'pipe', 'pipe'] });
+    let stdout = '';
+    let stderr = '';
+    child.stdout.on('data', (d) => {
+      stdout += d.toString();
+      process.stdout.write(d);
+    });
+    child.stderr.on('data', (d) => {
+      stderr += d.toString();
+      process.stderr.write(d);
+    });
+    child.on('close', (code) => {
+      resolve({ returncode: code ?? 0, stdout, stderr });
+    });
+  });
+}
+
+function buildInvokeArgs(contractId: string, source: string, network: string, send: string): string[] {
+  const args = [
+    'contract', 'invoke',
+    '--id', contractId,
+    '--source', source,
+    '--network', network,
+  ];
+  if (send === 'yes') {
+    args.push('--send', 'yes');
+  } else {
+    args.push('--send', 'no');
+  }
+  return args;
+}
+
+// === Commands ================================================================
+
+interface ProveArgs {
+  contract_id: string;
+  dataset: string;
+  source_account: string;
+  network: string;
+  send: string;
+  dry_run: boolean;
+}
+
+async function prove(args: ProveArgs) {
+  const artifacts = loadArtifacts(args.dataset);
+
+  console.log('--- Identity Proof Invocation ---');
+  console.log(`Contract ID:   ${args.contract_id}`);
+  console.log(`Network:       ${args.network}`);
+  console.log(`Public Inputs: ${artifacts.publicInputsBytes.length} bytes`);
+  console.log(`Proof:         ${artifacts.proofBytes.length} bytes`);
+  console.log('---------------------------------');
+
+  // Write temporary files for stellar CLI --file-path arguments
+  const tmpDir = fs.mkdtempSync(path.join(require('os').tmpdir(), 'identity-'));
+  const piFile = path.join(tmpDir, 'public_inputs');
+  const proofFile = path.join(tmpDir, 'proof');
+  fs.writeFileSync(piFile, artifacts.publicInputsBytes);
+  fs.writeFileSync(proofFile, artifacts.proofBytes);
+
+  const cmd = [
+    'stellar',
+    ...buildInvokeArgs(args.contract_id, args.source_account, args.network, args.send),
+    '--',
+    'prove_identity',
+    '--public_inputs-file-path', piFile,
+    '--proof_bytes-file-path', proofFile,
+  ];
+
+  try {
+    const result = await runCommand(cmd, args.dry_run);
+    if (result.returncode !== 0) {
+      process.exit(result.returncode);
+    }
+  } finally {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+}
+
+// === Main =====================================================================
+
+async function main() {
+  const parser = new ArgumentParser({ description: 'Identity contract client' });
+  const subparsers = parser.add_subparsers({ dest: 'command', required: true });
+
+  // prove command
+  const proveParser = subparsers.add_parser('prove', { help: 'Invoke prove_identity on the contract' });
+  proveParser.add_argument('--contract-id', { required: true, help: 'Contract address (C...)' });
+  proveParser.add_argument('--dataset', { default: DEFAULT_DATASET_DIR, help: 'Path to circuit target/ directory' });
+  proveParser.add_argument('--source-account', { default: 'alice', help: 'Stellar source account' });
+  proveParser.add_argument('--network', { default: 'local', help: 'Network name (local, testnet, mainnet)' });
+  proveParser.add_argument('--send', { default: 'yes', choices: ['yes', 'no'], help: 'Actually submit tx' });
+  proveParser.add_argument('--dry-run', { action: 'store_true', help: 'Print command without executing' });
+
+  // info command
+  const infoParser = subparsers.add_parser('info', { help: 'Print artifact sizes' });
+  infoParser.add_argument('--dataset', { default: DEFAULT_DATASET_DIR, help: 'Path to circuit target/ directory' });
+
+  const args = parser.parse_args();
+
+  if (args.command === 'prove') {
+    await prove(args as ProveArgs);
+  } else if (args.command === 'info') {
+    const artifacts = loadArtifacts(args.dataset);
+    console.log(`Public Inputs: ${artifacts.publicInputsBytes.length} bytes (${artifacts.publicInputsBytes.length / 32} fields)`);
+    console.log(`Proof:         ${artifacts.proofBytes.length} bytes (${artifacts.proofBytes.length / 32} fields)`);
+  }
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/scripts/invoke_identity/package.json
+++ b/scripts/invoke_identity/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "invoke-identity",
+  "version": "1.0.0",
+  "description": "Client for invoking the Identity contract on Soroban",
+  "scripts": {
+    "invoke": "ts-node invoke_identity.ts"
+  },
+  "dependencies": {
+    "argparse": "^2.0.1"
+  },
+  "devDependencies": {
+    "@types/argparse": "^2.0.10",
+    "@types/node": "^20.0.0",
+    "ts-node": "^10.9.0",
+    "typescript": "^5.0.0"
+  }
+}

--- a/scripts/measure_ultrahonk_costs/measure_ultrahonk_costs.ts
+++ b/scripts/measure_ultrahonk_costs/measure_ultrahonk_costs.ts
@@ -278,6 +278,10 @@ async function main() {
     action: 'store_true',
     help: 'Also submit the tx and report actual fee charged on-chain',
   });
+  parser.add_argument('--method', {
+    default: 'verify_proof',
+    help: 'Contract method to measure (default: verify_proof)',
+  });
 
   const args = parser.parse_args();
   const artifacts = loadArtifacts(args.dataset);
@@ -288,18 +292,19 @@ async function main() {
 
   console.log(`Dataset       : ${args.dataset}`);
   console.log(`Contract ID   : ${args.contract_id}`);
+  console.log(`Method        : ${args.method}`);
   console.log(`Source account: ${keypair.publicKey()}`);
 
-  const verifyResult = await measureMethod(
+  const result = await measureMethod(
     server,
     keypair,
     args.network_passphrase,
     args.contract_id,
-    'verify_proof',
+    args.method,
     [publicInputsScVal, proofBytesScVal],
     args.submit
   );
-  printResult('verify_proof', verifyResult);
+  printResult(args.method, result);
 }
 
 main().catch((err) => {

--- a/scripts/run_identity_e2e.sh
+++ b/scripts/run_identity_e2e.sh
@@ -1,0 +1,148 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# =============================================================================
+# Identity E2E — End-to-end flow for the Identity contract
+# =============================================================================
+# This script demonstrates the full flow of proving identity on-chain:
+#
+#   1. Build the Noir circuit (generate proof, vk, public inputs)
+#   2. Build the Soroban identity contract
+#   3. Deploy the contract with the verification key
+#   4. Call prove_identity() with the proof and public inputs
+#
+# Usage:
+#   ./scripts/run_identity_e2e.sh [network]
+#
+#   network: local (default) | testnet
+#
+# Example:
+#   ./scripts/run_identity_e2e.sh
+#   ./scripts/run_identity_e2e.sh testnet
+# =============================================================================
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+source "${SCRIPT_DIR}/config.sh"
+
+# Override network if provided
+if [[ "${1:-}" == "testnet" ]]; then
+  export STELLAR_NETWORK_NAME="testnet"
+  export STELLAR_RPC_URL="${STELLAR_RPC_URL:-https://soroban-testnet.stellar.org}"
+  export STELLAR_NETWORK_PASSPHRASE="${STELLAR_NETWORK_PASSPHRASE:-Test SDF Network ; September 2015}"
+fi
+
+# Start localnet automatically if needed
+if [[ "${STELLAR_NETWORK_NAME}" == "local" ]]; then
+  if ! curl -sf "${STELLAR_RPC_URL}" >/dev/null 2>&1; then
+    echo -e "${BLUE}Localnet not running, starting it...${NC}"
+    "${SCRIPT_DIR}/start_stellar.sh"
+  fi
+fi
+
+CIRCUIT_NAME="identity"
+CIRCUIT_DIR="${ROOT_DIR}/circuits/${CIRCUIT_NAME}"
+TARGET_DIR="${CIRCUIT_DIR}/target"
+CONTRACT_WASM="${ROOT_DIR}/target/wasm32v1-none/release/identity.wasm"
+IDENTITY_CONTRACT_ID_FILE="${ROOT_DIR}/.identity_contract_id"
+
+# ---------------------------------------------------------------------------
+# 1. Build circuit
+# ---------------------------------------------------------------------------
+echo -e "${BLUE}=== Step 1: Building identity circuit ===${NC}"
+just build-circuits "${CIRCUIT_NAME}"
+
+if [[ ! -f "${TARGET_DIR}/proof" || ! -f "${TARGET_DIR}/vk" || ! -f "${TARGET_DIR}/public_inputs" ]]; then
+  echo -e "${RED}Circuit artifacts missing in ${TARGET_DIR}${NC}"
+  exit 1
+fi
+
+PI_SIZE=$(stat -c%s "${TARGET_DIR}/public_inputs")
+PROOF_SIZE=$(stat -c%s "${TARGET_DIR}/proof")
+VK_SIZE=$(stat -c%s "${TARGET_DIR}/vk")
+
+echo "  Public inputs : ${PI_SIZE} bytes"
+echo "  Proof         : ${PROOF_SIZE} bytes"
+echo "  VK            : ${VK_SIZE} bytes"
+
+# ---------------------------------------------------------------------------
+# 2. Build contract
+# ---------------------------------------------------------------------------
+echo -e "${BLUE}=== Step 2: Building identity contract ===${NC}"
+stellar contract build
+
+if [[ ! -f "${CONTRACT_WASM}" ]]; then
+  echo -e "${RED}Contract WASM not found: ${CONTRACT_WASM}${NC}"
+  exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# 3. Fund account
+# ---------------------------------------------------------------------------
+echo -e "${BLUE}=== Step 3: Ensuring account is funded ===${NC}"
+"${SCRIPT_DIR}/fund_account.sh"
+
+# ---------------------------------------------------------------------------
+# 4. Deploy contract with VK
+# ---------------------------------------------------------------------------
+echo -e "${BLUE}=== Step 4: Deploying identity contract ===${NC}"
+DEPLOY_OK=0
+for attempt in $(seq 1 "${STELLAR_DEPLOY_RETRIES}"); do
+  echo "  Deployment attempt ${attempt}/${STELLAR_DEPLOY_RETRIES}..."
+  if CONTRACT_ID=$(stellar contract deploy \
+    --wasm "${CONTRACT_WASM}" \
+    --source "${STELLAR_SOURCE_ACCOUNT}" \
+    --network "${STELLAR_NETWORK_NAME}" \
+    -- \
+    --vk_bytes-file-path "${TARGET_DIR}/vk"); then
+    DEPLOY_OK=1
+    break
+  fi
+  echo -e "${RED}    Deployment failed, retrying in ${STELLAR_DEPLOY_RETRY_INTERVAL}s...${NC}"
+  sleep "${STELLAR_DEPLOY_RETRY_INTERVAL}"
+done
+
+if [[ "${DEPLOY_OK}" -ne 1 ]]; then
+  echo -e "${RED}Failed to deploy contract after ${STELLAR_DEPLOY_RETRIES} attempts.${NC}"
+  exit 1
+fi
+
+echo "${CONTRACT_ID}" > "${IDENTITY_CONTRACT_ID_FILE}"
+echo -e "${GREEN}  Contract deployed: ${CONTRACT_ID}${NC}"
+echo "  (saved to ${IDENTITY_CONTRACT_ID_FILE})"
+
+# ---------------------------------------------------------------------------
+# 5. Invoke prove_identity
+# ---------------------------------------------------------------------------
+echo -e "${BLUE}=== Step 5: Proving identity on-chain ===${NC}"
+stellar contract invoke \
+  --id "${CONTRACT_ID}" \
+  --source "${STELLAR_SOURCE_ACCOUNT}" \
+  --network "${STELLAR_NETWORK_NAME}" \
+  --send yes \
+  -- \
+  prove_identity \
+  --public_inputs-file-path "${TARGET_DIR}/public_inputs" \
+  --proof_bytes-file-path "${TARGET_DIR}/proof"
+
+echo -e "\n${GREEN}=== Identity proven successfully! ===${NC}"
+echo "  Contract: ${CONTRACT_ID}"
+echo "  Network:  ${STELLAR_NETWORK_NAME}"
+
+# ---------------------------------------------------------------------------
+# 6. Measure costs
+# ---------------------------------------------------------------------------
+if [[ "${STELLAR_NETWORK_NAME}" == "local" ]]; then
+  echo -e "${BLUE}=== Step 6: Measuring resource costs ===${NC}"
+  SOURCE_SECRET=$(stellar keys secret "${STELLAR_SOURCE_ACCOUNT}" | tail -n 1 | tr -d '[:space:]')
+  pushd "$ROOT_DIR/scripts/measure_ultrahonk_costs" >/dev/null
+  npm run measure -- \
+    --contract-id "${CONTRACT_ID}" \
+    --source-secret "${SOURCE_SECRET}" \
+    --dataset "${TARGET_DIR}" \
+    --rpc-url "${STELLAR_RPC_URL}" \
+    --network-passphrase "${STELLAR_NETWORK_PASSPHRASE}" \
+    --method prove_identity
+  popd >/dev/null
+fi

--- a/scripts/run_identity_e2e.sh
+++ b/scripts/run_identity_e2e.sh
@@ -58,9 +58,15 @@ if [[ ! -f "${TARGET_DIR}/proof" || ! -f "${TARGET_DIR}/vk" || ! -f "${TARGET_DI
   exit 1
 fi
 
-PI_SIZE=$(stat -c%s "${TARGET_DIR}/public_inputs")
-PROOF_SIZE=$(stat -c%s "${TARGET_DIR}/proof")
-VK_SIZE=$(stat -c%s "${TARGET_DIR}/vk")
+if [ "$(uname)" = "Darwin" ]; then
+    PI_SIZE=$(stat -f%z "${TARGET_DIR}/public_inputs")
+    PROOF_SIZE=$(stat -f%z "${TARGET_DIR}/proof")
+    VK_SIZE=$(stat -f%z "${TARGET_DIR}/vk")
+else
+    PI_SIZE=$(stat -c%s "${TARGET_DIR}/public_inputs")
+    PROOF_SIZE=$(stat -c%s "${TARGET_DIR}/proof")
+    VK_SIZE=$(stat -c%s "${TARGET_DIR}/vk")
+fi
 
 echo "  Public inputs : ${PI_SIZE} bytes"
 echo "  Proof         : ${PROOF_SIZE} bytes"

--- a/scripts/verify.sh
+++ b/scripts/verify.sh
@@ -24,8 +24,13 @@ if [ ! -f "$PUBLIC_INPUTS" ] || [ ! -f "$PROOF" ]; then
   exit 1
 fi
 
-PI_SIZE=$(stat -c%s "$PUBLIC_INPUTS")
-PROOF_SIZE=$(stat -c%s "$PROOF")
+if [ "$(uname)" = "Darwin" ]; then
+    PI_SIZE=$(stat -f%z "$PUBLIC_INPUTS")
+    PROOF_SIZE=$(stat -f%z "$PROOF")
+else
+    PI_SIZE=$(stat -c%s "$PUBLIC_INPUTS")
+    PROOF_SIZE=$(stat -c%s "$PROOF")
+fi
 
 echo -e "${BLUE}--- Artifact Summary ---${NC}"
 echo "Public Inputs : $PI_SIZE bytes"


### PR DESCRIPTION
# Summary

Add full documentation, client tooling, and justfile recipes for the Identity contract. The Identity contract (already present in the workspace) verifies on-chain proofs of knowledge of a Poseidon2 hash preimage using the embedded UltraHonk verifier. This PR provides the missing developer-experience layer: a README, a TypeScript invocation client, an end-to-end shell script, and convenient justfile recipes.

Also makes the cost-measurement script generic so it can measure any contract method (not just `verify_proof`).

# Changes

- **Identity Contract Documentation**
  - Added `contracts/identity/README.md` with architecture diagram, contract API, error reference, and step-by-step usage instructions.

- **Identity Contract Client (`scripts/invoke_identity/`)**
  - New TypeScript client `invoke_identity.ts` for calling `prove_identity` on localnet or testnet.
  - Includes `package.json` with `argparse`, `ts-node`, and `typescript` dependencies.

- **Identity E2E Script (`scripts/run_identity_e2e.sh`)**
  - New bash script automating the full pipeline: build circuit → build contract → deploy with VK → call `prove_identity`.
  - Supports both `local` (default) and `testnet` networks.

- **Justfile Updates**
  - Reorganized recipes into logical sections (General, Network, Circuits, Contracts, Identity).
  - Added `build-identity-contract` — build only the Identity contract WASM.
  - Added `deploy-identity` — deploy the Identity contract with the identity circuit's VK.
  - Added `verify-identity` — invoke `prove_identity` with circuit artifacts.
  - Added `identity-e2e` — run the full Identity E2E pipeline.
  - Moved `clean` recipe earlier and added `.identity_contract_id` cleanup.

- **Cost Measurement Enhancement**
  - `scripts/measure_ultrahonk_costs/measure_ultrahonk_costs.ts` now accepts a `--method` flag (default: `verify_proof`) so it can measure gas costs of arbitrary contract methods (e.g., `prove_identity`).

# Breaking changes

None. All changes are purely additive. Existing `deploy`, `e2e`, `testnet`, and `verify` recipes for the default Tornado contract remain unchanged.